### PR TITLE
Fix development redirect validation

### DIFF
--- a/functions/login.js
+++ b/functions/login.js
@@ -45,14 +45,25 @@ export async function onRequestOptions() {
   });
 }
 
+function parseUrlOrNull(url) {
+  try {
+    return new URL(url);
+  } catch (error) {
+    return null;
+  }
+}
+
 export async function onRequestGet({request}) {
   // Used during local development to redirect back to localhost.
   let url = new URL(request.url);
   let redirect = url.searchParams.get('redirect');
-  if (redirect.startsWith('http://localhost')) {
-    let redirectUrl = new URL(redirect);
-    redirectUrl.searchParams.set('code', url.searchParams.get('code'));
-    return Response.redirect(redirectUrl);
+  if (redirect) {
+    let redirectUrl = parseUrlOrNull(redirect);
+
+    if (redirectUrl && redirectUrl.hostname === 'localhost') {
+      redirectUrl.searchParams.set('code', url.searchParams.get('code'));
+      return Response.redirect(redirectUrl);
+    }
   }
 
   return new Response('Redirect not allowed', {status: 400});


### PR DESCRIPTION
`startsWith` is not enough to validate that the development redirect URL is safe. It's currently possible to use the dev redirect endpoint to redirect to any host with the OAuth code, which in turn allows fetching of the GH token. As GitHub redirects users automatically once they've authenticated with the app once, it's possible to retrieve GH tokens by just opening a specially crafted link.

To fix this, the _parsed_ redirect URL is used for validation.