### PR TITLE
feat: render GitHub discussion category emojis

### DIFF
--- a/src/Discussion.tsx
+++ b/src/Discussion.tsx
@@ -4,6 +4,7 @@ import Markdown from 'markdown-to-jsx';
 import { useState } from 'react';
 import { Button, Link } from 'react-aria-components';
 import { graphql, useQuery } from './client';
+import { useRenderGitHubEmojis } from './emoji';
 import { CommentCard, Reactions } from './CommentCard';
 import { CommentForm } from './CommentForm';
 import { Avatar, User } from './components';
@@ -82,6 +83,7 @@ ${Reactions.fragment}
 `;
 
 function DiscussionHeader({data}: {data: Discussion}) {
+  let renderGitHubEmojis = useRenderGitHubEmojis();
   return (
     <div className="flex flex-col gap-2 mb-2">
       <div className="flex gap-2 flex-wrap">
@@ -96,7 +98,7 @@ function DiscussionHeader({data}: {data: Discussion}) {
           {data.closed ? 'Closed' : 'Open'}
         </span>
         <span className="w-fit px-2 py-0.5 rounded border text-sm font-medium bg-daw-purple-100 border-daw-purple-200 text-daw-purple-700">
-          {data.category.emoji} {data.category.name}
+          {renderGitHubEmojis(data.category.emoji)} {data.category.name}
         </span>
       </div>
       <h1 className="text-2xl font-semibold"><Markdown>{data.title}</Markdown></h1>

--- a/src/Discussions.tsx
+++ b/src/Discussions.tsx
@@ -8,6 +8,7 @@ import { CheckCircleIcon, CommentDiscussionIcon } from '@primer/octicons-react';
 import { List, ListItem, EmptyDetail } from './List';
 import { Button, Input, RadioGroup, TextField } from 'react-aria-components';
 import { FilterSection, RadioItem, SearchBar, FilterPopoverWrapper, DISCUSSION_SORT_OPTIONS } from './Filters';
+import { useRenderGitHubEmojis } from './emoji';
 
 type DiscussionItem = {
   id: string;
@@ -200,6 +201,7 @@ function DiscussionFilterPopover({
   categories,
   activeCount, onClear
 }: DiscussionFilterPopoverProps) {
+  const renderGitHubEmojis = useRenderGitHubEmojis();
   return (
     <FilterPopoverWrapper activeCount={activeCount}>
       <FilterSection label="Status">
@@ -229,7 +231,7 @@ function DiscussionFilterPopover({
           <FilterSection label="Category">
             <RadioGroup value={category} onChange={onCategoryChange} aria-label="Category" className="flex flex-col gap-1">
               <RadioItem value="" label="Any" />
-              {categories.map(c => <RadioItem key={c.id} value={c.name} label={`${c.emoji} ${c.name}`} />)}
+              {categories.map(c => <RadioItem key={c.id} value={c.name} label={renderGitHubEmojis(`${c.emoji} ${c.name}`)} />)}
             </RadioGroup>
           </FilterSection>
         </>

--- a/src/Filters.tsx
+++ b/src/Filters.tsx
@@ -45,7 +45,7 @@ export function FilterSection({label, children}: {label: string, children: React
   );
 }
 
-export function RadioItem({value, label, color}: {value: string, label: string, color?: string}) {
+export function RadioItem({value, label, color}: {value: string, label: ReactNode, color?: string}) {
   return (
     <Radio value={value} className="flex items-center gap-2 text-sm cursor-default outline-none focus-visible:ring-2 ring-blue-600 rounded py-0.5">
       {({isSelected}) => (

--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -1,0 +1,100 @@
+import { createElement, ReactNode, useCallback } from "react";
+import useSWR from "swr";
+import { github } from "./client";
+
+// GitHub's GraphQL API returns emoji as shortcodes rather than Unicode (for
+// example DiscussionCategory.emoji returns ":bulb:"), so we render them for
+// display. GitHub's emoji REST API (https://api.github.com/emojis) maps each
+// shortcode to an image URL; standard emoji encode their Unicode codepoint(s)
+// in the path, e.g. .../unicode/1f64f.png, which we turn back into the actual
+// emoji character. Custom GitHub emoji (e.g. :shipit:) have no Unicode form, so
+// we render the image URL that GitHub provides.
+const UNICODE_RE = /\/unicode\/([0-9a-f-]+)\.png/i;
+
+type GitHubEmoji =
+  | { kind: "unicode"; value: string }
+  | { kind: "image"; url: string };
+
+async function fetchEmojis(): Promise<Record<string, GitHubEmoji>> {
+  const { data } = await github.emojis.get();
+  const map: Record<string, GitHubEmoji> = {};
+  for (const [name, url] of Object.entries(data as Record<string, string>)) {
+    const match = url.match(UNICODE_RE);
+    if (match) {
+      map[name] = {
+        kind: "unicode",
+        value: match[1]
+          .split("-")
+          .map((cp) => String.fromCodePoint(parseInt(cp, 16)))
+          .join(""),
+      };
+    } else {
+      map[name] = { kind: "image", url };
+    }
+  }
+  return map;
+}
+
+const SHORTCODE_RE = /:([a-z0-9_+-]+):/gi;
+
+function renderEmoji(name: string, emoji: GitHubEmoji, key: string): ReactNode {
+  if (emoji.kind === "unicode") {
+    return emoji.value;
+  }
+
+  return createElement("img", {
+    key,
+    src: emoji.url,
+    alt: `:${name}:`,
+    title: `:${name}:`,
+    loading: "lazy",
+    decoding: "async",
+    className: "inline-block h-[1em] w-[1em] align-[-0.125em]",
+  });
+}
+
+// Returns a function that renders any `:shortcode:` tokens in `text`. The
+// shortcode map is fetched once from GitHub and cached by SWR; until it loads
+// (or for unknown shortcodes) the text is returned unchanged.
+export function useRenderGitHubEmojis(): (text: string) => ReactNode {
+  const { data: map } = useSWR("github-emojis", fetchEmojis);
+  return useCallback(
+    (text: string) => {
+      if (!map) {
+        return text;
+      }
+
+      const nodes: ReactNode[] = [];
+      let lastIndex = 0;
+      let hasEmoji = false;
+
+      for (const match of text.matchAll(SHORTCODE_RE)) {
+        const [shortcode, name] = match;
+        const index = match.index ?? 0;
+        const emoji = map[name.toLowerCase()];
+
+        if (!emoji) {
+          continue;
+        }
+
+        if (index > lastIndex) {
+          nodes.push(text.slice(lastIndex, index));
+        }
+        nodes.push(renderEmoji(name, emoji, `${name}-${index}`));
+        lastIndex = index + shortcode.length;
+        hasEmoji = true;
+      }
+
+      if (!hasEmoji) {
+        return text;
+      }
+
+      if (lastIndex < text.length) {
+        nodes.push(text.slice(lastIndex));
+      }
+
+      return nodes;
+    },
+    [map],
+  );
+}


### PR DESCRIPTION
Render GitHub discussion category emoji shortcodes as Unicode emoji or images. Uses their emoji API: https://api.github.com/emojis

Before:

<img width="688" height="128" alt="Screenshot 2026-06-01 at 10 05 42 PM" src="https://github.com/user-attachments/assets/5b84e552-76fb-4c4f-82ca-9cc1bc90bbf1" />

After:

<img width="688" height="128" alt="Screenshot 2026-06-01 at 10 05 18 PM" src="https://github.com/user-attachments/assets/e857229a-b074-4e9b-a504-7c7d8befdf73" />

