### PR TITLE
feat: format issue/PR/discussion/commit URLs as a short reference

### DIFF
--- a/src/Discussion.tsx
+++ b/src/Discussion.tsx
@@ -9,6 +9,7 @@ import { CommentCard, Reactions } from './CommentCard';
 import { CommentForm } from './CommentForm';
 import { Avatar, User } from './components';
 import { mutate } from 'swr';
+import { RepoContext } from './SlideOver';
 
 export function DiscussionPage({owner, repo, number}: {owner: string, repo: string, number: number}) {
   let { data: res } = useQuery<{repository: Repository}>(DiscussionPage.query(), {owner, repo, number});
@@ -30,14 +31,16 @@ export function DiscussionPage({owner, repo, number}: {owner: string, repo: stri
   }
 
   return (
-    <div className="flex flex-col gap-4 my-4 w-full max-w-3xl mx-auto">
-      <DiscussionHeader data={data} />
-      <CommentCard data={data} />
-      {data.comments.nodes?.map(comment => comment && (
-        <DiscussionCommentItem key={comment.id} comment={comment} onDelete={deleteComment} onReply={addComment} />
-      ))}
-      <CommentForm onSubmit={addComment}>{null}</CommentForm>
-    </div>
+    <RepoContext.Provider value={{owner, repo}}>
+      <div className="flex flex-col gap-4 my-4 w-full max-w-3xl mx-auto">
+        <DiscussionHeader data={data} />
+        <CommentCard data={data} />
+        {data.comments.nodes?.map(comment => comment && (
+          <DiscussionCommentItem key={comment.id} comment={comment} onDelete={deleteComment} onReply={addComment} />
+        ))}
+        <CommentForm onSubmit={addComment}>{null}</CommentForm>
+      </div>
+    </RepoContext.Provider>
   );
 }
 

--- a/src/Issue.tsx
+++ b/src/Issue.tsx
@@ -9,7 +9,7 @@ import { Timeline } from './Timeline';
 import { CommentCard } from './CommentCard';
 import { Avatar, BranchName, Card, GithubLabel, IssueStatus, IssueTypeBadge } from './components';
 import { IssueCommentForm } from './CommentForm';
-import { GitHubLink } from './SlideOver';
+import { GitHubLink, RepoContext } from './SlideOver';
 
 export function IssuePage({owner, repo, number}: {owner: string, repo: string, number: number}) {
   let { data: res } = useQuery<{repository: Repository}>(IssuePage.query(), {owner, repo, number});
@@ -24,17 +24,19 @@ export function IssuePage({owner, repo, number}: {owner: string, repo: string, n
   }
 
   return (
-    <div className="flex flex-1 justify-center min-h-0 overflow-hidden">
-      <div className="overflow-y-auto">
-        <div className="flex flex-col gap-4 my-4 max-w-3xl mx-auto px-4">
-          <Header data={data} />
-          <CommentCard data={data} />
-          <Timeline items={data.timelineItems.nodes!} onDeleteComment={deleteComment} />
-          <IssueCommentForm issue={data} />
+    <RepoContext.Provider value={{owner, repo}}>
+      <div className="flex flex-1 justify-center min-h-0 overflow-hidden">
+        <div className="overflow-y-auto">
+          <div className="flex flex-col gap-4 my-4 max-w-3xl mx-auto px-4">
+            <Header data={data} />
+            <CommentCard data={data} />
+            <Timeline items={data.timelineItems.nodes!} onDeleteComment={deleteComment} />
+            <IssueCommentForm issue={data} />
+          </div>
         </div>
+        <IssueSidebar data={data} />
       </div>
-      <IssueSidebar data={data} />
-    </div>
+    </RepoContext.Provider>
   );
 }
 

--- a/src/PullRequest.tsx
+++ b/src/PullRequest.tsx
@@ -10,6 +10,7 @@ import { CommentCard } from './CommentCard';
 import { Timeline } from './Timeline';
 import { IssueCommentForm, CommentForm } from './CommentForm';
 import { Card, Status, User } from './components';
+import { RepoContext } from './SlideOver';
 import useSWR, {preload as swrPreload, mutate} from 'swr';
 import { CommentIcon } from '@primer/octicons-react';
 
@@ -136,6 +137,7 @@ export function PullRequestPage({owner, repo, number}: {owner: string, repo: str
 
   return (
     <PullRequestContext.Provider value={data}>
+    <RepoContext.Provider value={{owner, repo}}>
       <div className="flex flex-1 min-h-0">
         <div className="flex flex-col gap-4 px-4 pb-4 pt-2 -mr-4 max-w-3xl mx-auto w-[500px] overflow-auto text-sm">
           <Header data={data} />
@@ -204,6 +206,7 @@ export function PullRequestPage({owner, repo, number}: {owner: string, repo: str
           </div>
         </div>
       </div>
+    </RepoContext.Provider>
     </PullRequestContext.Provider>
   );
 }

--- a/src/SlideOver.tsx
+++ b/src/SlideOver.tsx
@@ -27,6 +27,9 @@ export function useSlideOver() {
   return useContext(SlideOverContext);
 }
 
+// The repository whose content is currently being displayed.
+export const RepoContext = createContext<{owner: string, repo: string} | null>(null);
+
 export function parseGitHubUrl(url: string): SlideOverContent | null {
   try {
     const parsed = new URL(url);
@@ -206,9 +209,44 @@ function preloadContent(content: SlideOverContent) {
   }
 }
 
+// Formats an issue/PR/discussion/commit URL as a short reference, e.g. "#123", "owner/repo#123", or "abc1234".
+function formatGitHubReference(href: string, content: SlideOverContent, currentRepo: {owner: string, repo: string} | null): string | null {
+  const url = new URL(href);
+  if (url.pathname.split('/').filter(Boolean).length !== 4 || url.search) {
+    return null;
+  }
+
+  const isCurrentRepo = currentRepo
+    && content.owner.toLowerCase() === currentRepo.owner.toLowerCase()
+    && content.repo.toLowerCase() === currentRepo.repo.toLowerCase();
+  if (content.type === 'commit') {
+    if (!/^[0-9a-f]{40}$/.test(content.sha)) {
+      return null;
+    }
+    const sha = content.sha.slice(0, 7);
+    return isCurrentRepo ? sha : `${content.owner}/${content.repo}@${sha}`;
+  }
+
+  let suffix = '';
+  if (/^#(issuecomment|discussioncomment)-/.test(url.hash)) {
+    suffix = ' (comment)';
+  } else if (/^#pullrequestreview-/.test(url.hash)) {
+    suffix = ' (review)';
+  }
+  const prefix = isCurrentRepo ? '' : `${content.owner}/${content.repo}`;
+  return `${prefix}#${content.number}${suffix}`;
+}
+
 export function GitHubLink({ href, children, className, ...props }: LinkProps) {
   const { open } = useSlideOver();
+  const currentRepo = useContext(RepoContext);
   const content = href ? parseGitHubUrl(href) : null;
+
+  // Autolinked bare URLs (link text is the URL itself) render as short references.
+  const text = Array.isArray(children) && children.length === 1 ? children[0] : children;
+  if (href && content && typeof text === 'string' && text === href) {
+    children = formatGitHubReference(href, content, currentRepo) ?? children;
+  }
 
   if (content) {
     return (


### PR DESCRIPTION
GitHub issue/PR links in markdown now render as short references (like on github.com).

Rendering matches these rules:

| URL in a post (viewing `adobe/react-spectrum`) | Renders as |
|---|---|
| `…/adobe/react-spectrum/issues/10184` | `#10184` |
| `…/facebook/react/pull/123` | `facebook/react#123` |
| `…/issues/10184#issuecomment-99887` | `#10184 (comment)` |
| `…/pull/555#pullrequestreview-1` | `#555 (review)` |
| `…/adobe/react-spectrum/discussions/42` | `#42` |
| `…/commit/<full sha>` | `0123456` (or `facebook/react@0123456` cross-repo) |
