### PR TITLE
feat: render embedded code for permalinks

### DIFF
--- a/src/CodeReference.tsx
+++ b/src/CodeReference.tsx
@@ -1,0 +1,156 @@
+import { Blob, Repository } from '@octokit/graphql-schema';
+import { File, FileContents, FileOptions } from '@pierre/diffs';
+import { isValidElement, ReactNode, useLayoutEffect, useMemo, useRef } from 'react';
+import { Link } from 'react-aria-components';
+import { useQuery } from './client';
+import { GitHubLink } from './SlideOver';
+
+export interface CodeReference {
+  owner: string;
+  repo: string;
+  sha: string;
+  path: string;
+  start: number;
+  end: number;
+  url: string;
+}
+
+const MAX_LINES = 200;
+const FRAGMENT_REGEX = /^L(\d+)(?:C\d+)?(?:-L(\d+)(?:C\d+)?)?$/;
+
+// Parses GitHub permalinks like
+// https://github.com/{owner}/{repo}/blob/{sha}/{path}#L46-L47
+// Only full commit SHAs are embedded since branch contents can change.
+export function parseCodeReference(url: string): CodeReference | null {
+  try {
+    let parsed = new URL(url);
+    if (parsed.hostname !== 'github.com') return null;
+    let match = FRAGMENT_REGEX.exec(parsed.hash.slice(1));
+    if (!match) return null;
+    let [owner, repo, type, sha, ...pathParts] = parsed.pathname.split('/').filter(Boolean);
+    if (type !== 'blob' || !sha || !/^[0-9a-f]{40}$/i.test(sha) || pathParts.length === 0) return null;
+    let path = pathParts.map(decodeURIComponent).join('/');
+    let start = parseInt(match[1], 10);
+    let end = match[2] ? parseInt(match[2], 10) : start;
+    if (start < 1) return null;
+    if (end < start) [start, end] = [end, start];
+    return {owner, repo, sha, path, start, end, url};
+  } catch {
+    return null;
+  }
+}
+
+// Returns a CodeReference if the given element is a bare autolinked permalink
+// (like github.com, [text](url) links stay links).
+function getLinkReference(child: ReactNode): CodeReference | null {
+  if (!isValidElement(child)) return null;
+  let {href, children: linkChildren} = child.props as {href?: unknown, children?: ReactNode};
+  if (typeof href !== 'string') return null;
+  let text = Array.isArray(linkChildren) && linkChildren.length === 1 ? linkChildren[0] : linkChildren;
+  if (text !== href) return null;
+  return parseCodeReference(href);
+}
+
+// Replaces bare permalink links anywhere in the given children with embedded
+// code snippets. Returns null if there are none.
+export function replaceCodeReferences(children: ReactNode): ReactNode[] | null {
+  let array = Array.isArray(children) ? children : [children];
+  let found = false;
+  let result = array.map((child, i) => {
+    let reference = getLinkReference(child);
+    if (reference) {
+      found = true;
+      return <CodeReferenceCard key={i} reference={reference} />;
+    }
+    return child;
+  });
+  return found ? result : null;
+}
+
+const blobQuery = `
+query CodeReferenceBlob($owner: String!, $name: String!, $expression: String!) {
+  repository(owner: $owner, name: $name) {
+    object(expression: $expression) {
+      ... on Blob {
+        text
+        isBinary
+      }
+    }
+  }
+}
+`;
+
+export function CodeReferenceCard({reference}: {reference: CodeReference}) {
+  let {owner, repo, sha, path, url, start} = reference;
+  let {data, error} = useQuery<{repository: Repository | null}>(blobQuery, {owner, name: repo, expression: `${sha}:${path}`});
+  let blob = data?.repository?.object as Blob | null | undefined;
+  let lineCount = useMemo(() => {
+    if (blob?.text == null) return null;
+    let count = blob.text.split('\n').length;
+    return blob.text.endsWith('\n') ? count - 1 : count;
+  }, [blob]);
+
+  let failed = error != null
+    || (data != null && (blob?.text == null || blob.isBinary))
+    || (lineCount != null && start > lineCount);
+  if (failed) {
+    return (
+      <p className="my-2" style={{wordBreak: 'break-word'}}>
+        <GitHubLink href={url} className="underline">{url}</GitHubLink>
+      </p>
+    );
+  }
+
+  let end = Math.min(reference.end, start + MAX_LINES - 1, lineCount ?? Infinity);
+  return (
+    <div className="code-reference my-2 border border-daw-gray-200 rounded-xl overflow-hidden">
+      <div className="px-3 py-2 text-xs flex flex-col gap-0.5 border-b border-daw-gray-200 bg-daw-gray-50">
+        <Link href={url} target="_blank" className="font-semibold text-daw-blue-800 hover:underline w-fit [word-break:break-all]">
+          {repo}/{path}
+        </Link>
+        <span className="text-daw-gray-600">
+          {start === end ? `Line ${start}` : `Lines ${start} to ${end}`} in{' '}
+          <GitHubLink href={`https://github.com/${owner}/${repo}/commit/${sha}`} className="font-mono underline">{sha.slice(0, 7)}</GitHubLink>
+        </span>
+      </div>
+      {blob?.text != null
+        ? (
+          <div className="max-h-96 overflow-y-auto">
+            <Snippet path={path} contents={blob.text} start={start} end={end} />
+          </div>
+        )
+        : <div className="animate-pulse bg-daw-gray-100" style={{height: Math.min(end - start + 1, 19) * 20 + 16}} />}
+    </div>
+  );
+}
+
+const SNIPPET_OPTIONS: FileOptions<undefined> = {
+  theme: { dark: 'pierre-dark', light: 'pierre-light' },
+  themeType: 'system',
+  disableFileHeader: true
+};
+
+// Renders a window of the full file so the gutter shows the true line numbers.
+// The React File wrapper doesn't expose renderRange, so this drives the
+// imperative File class directly.
+function Snippet({path, contents, start, end}: {path: string, contents: string, start: number, end: number}) {
+  let ref = useRef<HTMLDivElement | null>(null);
+  let file: FileContents = useMemo(() => ({name: path, contents}), [path, contents]);
+
+  useLayoutEffect(() => {
+    let instance = new File(SNIPPET_OPTIONS);
+    instance.render({
+      file,
+      containerWrapper: ref.current!,
+      renderRange: {
+        startingLine: start - 1,
+        totalLines: end - start + 1,
+        bufferBefore: 0,
+        bufferAfter: 0
+      }
+    });
+    return () => instance.cleanUp();
+  }, [file, start, end]);
+
+  return <div ref={ref} />;
+}

--- a/src/CommentCard.tsx
+++ b/src/CommentCard.tsx
@@ -8,6 +8,7 @@ import { Avatar, Card } from './components';
 import { graphql } from './client';
 import { File } from '@pierre/diffs/react';
 import { GitHubLink } from './SlideOver';
+import { replaceCodeReferences } from './CodeReference';
 
 export function CommentCard({data, onDelete}: {data: Issue | PullRequest | IssueComment | Discussion | DiscussionComment, onDelete?: () => Promise<void>}) {
   let df = useDateFormatter({
@@ -86,6 +87,9 @@ export function CommentBody({children}: {children: string}) {
   return (
     <Markdown className="[word-break:break-word]" options={{
       disableParsingRawHTML: true,
+      // Always wrap in block elements so single-paragraph comments go through
+      // the p override below.
+      forceBlock: true,
       overrides: {
         img: {props: {style: {maxWidth: '100%'}}},
         pre: {
@@ -122,6 +126,15 @@ export function CommentBody({children}: {children: string}) {
           component: (props: any) => <GitHubLink {...props} className="underline">{props.children}</GitHubLink>
         },
         p: {
+          component: (props: any) => {
+            // Bare permalinks render as code snippets, like github.com.
+            // A div is used instead of a p since the snippets are blocks.
+            let replaced = replaceCodeReferences(props.children);
+            if (replaced) {
+              return replaced.length === 1 ? replaced[0] : <div {...props}>{replaced}</div>;
+            }
+            return <p {...props} />;
+          },
           props: {
             className: 'my-2',
             style: {
@@ -136,6 +149,10 @@ export function CommentBody({children}: {children: string}) {
           props: {className: 'list-decimal pl-4'}
         },
         li: {
+          component: (props: any) => {
+            let replaced = replaceCodeReferences(props.children);
+            return replaced ? <li {...props}>{replaced}</li> : <li {...props} />;
+          },
           props: {
             className: 'my-1'
           }

--- a/src/index.css
+++ b/src/index.css
@@ -119,3 +119,8 @@ diffs-container {
   border: none;
   box-shadow: var(--shadow);
 }
+
+.code-reference diffs-container {
+  border: none;
+  border-radius: 0;
+}


### PR DESCRIPTION
For GitHub permalinks containing line ranges, render them as embedded code reference cards.

Before:

<img width="763" height="554" alt="Github comment without embedded code" src="https://github.com/user-attachments/assets/f598a561-f049-4f41-b2fb-9169c4c5e038" />


After:

<img width="763" height="678" alt="Github comment with embedded code" src="https://github.com/user-attachments/assets/852e211e-2e78-4e00-b20f-fdc086c7abf4" />
